### PR TITLE
Fix missing generic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ namespace Signal {
 
     namespace unsafe {
         // Run a callback with all tracking disabled (even for nested computed).
-        function untrack(cb: () => T): T;
+        function untrack<T>(cb: () => T): T;
     }
 }
 


### PR DESCRIPTION
It wasn't completely apparent where `T` was coming from on `untracked`.