### PR TITLE
Refactor example A

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-    root: 'example',
+    root: 'examples/example-a',
 })


### PR DESCRIPTION
This PR refactors the example A implementation so that it aligns with the README.md. This means that ownership and cleanup are now layered on top via subclassing and the tests have been updated, along with the example, to reflect that.