### PR TITLE
Treat reads/exceptions during `equals` as if the computed had performed them

### DIFF
--- a/packages/signal-polyfill/src/computed.ts
+++ b/packages/signal-polyfill/src/computed.ts
@@ -114,8 +114,11 @@ const COMPUTED_NODE = /* @__PURE__ */ (() => {
 
       const prevConsumer = consumerBeforeComputation(node);
       let newValue: unknown;
+      let wasEqual = false;
       try {
         newValue = node.computation.call(node.wrapper);
+        const oldOk = oldValue !== UNSET && oldValue !== ERRORED;
+        wasEqual = oldOk && node.equal.call(node.wrapper, oldValue, newValue);
       } catch (err) {
         newValue = ERRORED;
         node.error = err;
@@ -123,8 +126,7 @@ const COMPUTED_NODE = /* @__PURE__ */ (() => {
         consumerAfterComputation(node, prevConsumer);
       }
 
-      if (oldValue !== UNSET && oldValue !== ERRORED && newValue !== ERRORED &&
-          node.equal.call(node.wrapper, oldValue, newValue)) {
+      if (wasEqual) {
         // No change to `valueVersion` - old and new values are
         // semantically equivalent.
         node.value = oldValue;


### PR DESCRIPTION
Fixes https://github.com/proposal-signals/proposal-signals/issues/67.

Frameworks can get other behavior by wrapping user-provided equality functions, e.g. to untrack them or to augment or report errors differently. Given that you can't un-wrap or un-hide the errors, or un-untrack the reads, this choice seemed like the most primitive one for libraries to experiment on top of that still avoids the surprising leakage behavior.