### PR TITLE
Fix the `effect` example in the polyfill's readme

### DIFF
--- a/packages/signal-polyfill/readme.md
+++ b/packages/signal-polyfill/readme.md
@@ -51,12 +51,12 @@ Depending on how the effect is implemented, the above code could result in an in
 ```js
 import { Signal } from "signal-polyfill";
 
-let needsEnqueue = false;
+let needsEnqueue = true;
 
 const w = new Signal.subtle.Watcher(() => {
   if (needsEnqueue) {
     needsEnqueue = false;
-    queueMicrotask.enqueue(processPending);
+    queueMicrotask(processPending);
   }
 });
 


### PR DESCRIPTION
I was playing with the example of the `effect` function from the polyfill package and noticed that the effects only ran once – any changes to watched signals were ignored. It seems like the `needsEnqueue` var in the example has to be set to `true` initially in order to let the watcher work. Another thing is that `queueMicrotask.enqueue` doesn't seem to be a valid API, so I've replaced it with `queueMicrotask`. 

Here's a simple reproduction:
https://stackblitz.com/edit/vitejs-vite-t9zm1t?file=src%2Feffect.ts%3AL3&terminal=dev

Click on the button, observe that the label doesn't change. Then change the initial value from `false` to `true`, let the preview reload and click on the button again – this time everything should work as expected.