### PR TITLE
style(wrapper.ts): spacing

### DIFF
--- a/packages/signal-polyfill/src/wrapper.ts
+++ b/packages/signal-polyfill/src/wrapper.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
- import {
+import {
   computedGet,
   createComputed,
   type ComputedNode,


### PR DESCRIPTION
likely added when License was included