### PR TITLE
Fix `self` param into watcher notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,13 +347,13 @@ The `Watcher` interface defined above gives the basis for implementing typical J
 // NOTE: This scheduling logic is too basic to be useful. Do not copy/paste.
 let pending = false;
 
-let w = new Signal.subtle.Watcher(() => {
+let w = new Signal.subtle.Watcher((self) => {
     if (!pending) {
         pending = true;
         queueMicrotask(() => {
             pending = false;
-            for (let s of this.getPending()) s.get();
-            this.watch();
+            for (let s of self.getPending()) s.get();
+            self.watch();
         });
     }
 });

--- a/packages/signal-polyfill/src/wrapper.spec.ts
+++ b/packages/signal-polyfill/src/wrapper.spec.ts
@@ -195,6 +195,36 @@ describe("Watcher", () => {
     flushPending();
 
   });
+
+  it("provides `this` via `self` param to notify as arrow function", () => {
+    const mockGetPending = vi.fn();
+
+    const watcher = new Signal.subtle.Watcher((self) => {
+      self.getPending();
+    });
+    watcher.getPending = mockGetPending;
+
+    const signal = new Signal.State<number>(0);
+    watcher.watch(signal);
+
+    signal.set(1);
+    expect(mockGetPending).toBeCalled();
+  });
+
+  it("provides `this` via `self` param to notify as normal function", () => {
+    const mockGetPending = vi.fn();
+
+    const watcher = new Signal.subtle.Watcher(function(self) {
+      self.getPending();
+    });
+    watcher.getPending = mockGetPending;
+
+    const signal = new Signal.State<number>(0);
+    watcher.watch(signal);
+
+    signal.set(1);
+    expect(mockGetPending).toBeCalled();
+  });
 });
 
 describe("Expected class shape", () => {

--- a/packages/signal-polyfill/src/wrapper.ts
+++ b/packages/signal-polyfill/src/wrapper.ts
@@ -203,10 +203,12 @@ export namespace subtle {
     // When a (recursive) source of Watcher is written to, call this callback,
     // if it hasn't already been called since the last `watch` call.
     // No signals may be read or written during the notify.
-    constructor(notify: (this: Watcher) => void) {
+    constructor(notify: (self: Watcher) => void) {
       let node = Object.create(REACTIVE_NODE);
       node.wrapper = this;
-      node.consumerMarkedDirty = notify;
+      // Wrap notify to provide `this` access
+      // `consumerMarkedDirty` is called from the ReactiveNode context, not Watcher
+      node.consumerMarkedDirty = () => notify(this);
       node.consumerIsAlwaysLive = true;
       node.consumerAllowSignalWrites = false;
       node.producerNode = [];


### PR DESCRIPTION
We must wrap the notify call in order to give access to `this` inside watcher constructor.  This is because when `consumerMarkedDirty` is called it is actually in the ReactiveNode context and can only pass in the node as the self argument.  The node is not useful inside notify because the main thing a user would want to do in here is use the watcher object's functions like `getPending` and `watch`.

Also, there was some discussion of removing the `self` param all together in favor of `this`.  However that does not work because in the case of an arrow function it is defined in the global context and in the case of a normal function we arent taking the steps to bind because it could possibly be an arrow function.  So update the README as well to back to the `self` way, it is better than before because `self` is actually passed in as a param this time.  Keep the self name over `this` in the type declaration in the case of an arrow function, Typescript doesnt like params named `this`.

Add unit tests to describe these cases.